### PR TITLE
Updated https://github.com/easylist/antiadblockfilters/pull/3

### DIFF
--- a/antiadblockfilters/antiadblock_dutch.txt
+++ b/antiadblockfilters/antiadblock_dutch.txt
@@ -1,4 +1,9 @@
-bouweenpc.nl###header-banner
-rtlxl.nl##.adblock
-spele.nl##.adblocker
-koolhydraatarmerecepten.info##body > [style^="z-index: 1000000; "]
+@@*$generichide,domain=ah.nl|goplay.be|kijk.nl|modekoninginmaxima.nl|quickclaims.nl
+dumpert.nl#@#.ads_box
+fok.nl#@##advertentie
+@@||hb.improvedigital.com/pbw/headerlift.min.js$script,third-party,domain=funnygames.be|funnygames.nl|spele.be|spele.nl
+||goplay.be/js/sourcepoint/msg?v=
+@@*&ad$xhr,domain=kijk.nl
+@@||ads-talpa.adhese.com/json/$xhr,domain=kijk.nl
+meerdangewenst.nl##[class*="footer-section"] > *:style(display: none !important;)
+@@||quantcast.mgr.consensu.org/tcfv2/*/cmp2.js$script,domain=www.vi.nl

--- a/antiadblockfilters/antiadblock_dutch.txt
+++ b/antiadblockfilters/antiadblock_dutch.txt
@@ -3,7 +3,4 @@ dumpert.nl#@#.ads_box
 fok.nl#@##advertentie
 @@||hb.improvedigital.com/pbw/headerlift.min.js$script,third-party,domain=funnygames.be|funnygames.nl|spele.be|spele.nl
 ||goplay.be/js/sourcepoint/msg?v=
-@@*&ad$xhr,domain=kijk.nl
-@@||ads-talpa.adhese.com/json/$xhr,domain=kijk.nl
-meerdangewenst.nl##[class*="footer-section"] > *:style(display: none !important;)
 @@||quantcast.mgr.consensu.org/tcfv2/*/cmp2.js$script,domain=www.vi.nl

--- a/antiadblockfilters/antiadblock_dutch.txt
+++ b/antiadblockfilters/antiadblock_dutch.txt
@@ -3,4 +3,6 @@ dumpert.nl#@#.ads_box
 fok.nl#@##advertentie
 @@||hb.improvedigital.com/pbw/headerlift.min.js$script,third-party,domain=funnygames.be|funnygames.nl|spele.be|spele.nl
 ||goplay.be/js/sourcepoint/msg?v=
+@@*&ad$xmlhttprequest,domain=kijk.nl
+@@||ads-talpa.adhese.com/json/$xmlhttprequest,domain=kijk.nl
 @@||quantcast.mgr.consensu.org/tcfv2/*/cmp2.js$script,domain=www.vi.nl


### PR DESCRIPTION
As @dimisa-RUAdList said

> These rules are invalid for Adblock Plus:
> 
> ```
> @@*&ad$xhr,domain=kijk.nl
> @@||ads-talpa.adhese.com/json/$xhr,domain=kijk.nl
> meerdangewenst.nl##[class*="footer-section"] > *:style(display: none !important;)
> ```

I have removed them. It's ok now.