### PR TITLE
Add Tumblr filter

### DIFF
--- a/antiadblockfilters/antiadblock_english.txt
+++ b/antiadblockfilters/antiadblock_english.txt
@@ -131,6 +131,7 @@ euroiphone.eu##.div-download-v
 findretros.com##.fuck-adblock
 technologypep.com##.main-container-wrap > div[class$="-bg"]
 technologypep.com##.main-container-wrap > div[id][class][style*="opacity"]
+tumblr.com##+js(nostif, adFreeCtaBanner)
 biggestplayer.me##.masr
 videobug.net,videofun.me,vidzur.com##.randid
 toolslib.net##.row > .col-md-7 > .panel-default


### PR DESCRIPTION
Tumblr.com nags you to buy their ad-free subscription if you have adblock enabled. This disables the banner.